### PR TITLE
Add a section on non-CHIPS projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,14 @@ Linux Foundation staff are able to help with this process.
 
 * [Project 6](LINK-TO-PROJECT-6)-->
 
+### The CHIPS Alliance Commons: Related projects and initiatives
+
+The CHIPS Alliance exists within a rich ecosystem of interrelated projects. While the TSC's first objective is to support the success of CHIPS Alliance projects, it also acknowledges the critical strategic roles played by external projects. Collectively, we refer to these projects as "The CHIPS Alliance Commons".
+
+Although these projects remain outside of the CHIPS Alliance organization and its policies, the TSC may recognize these projects in various ways. For example, the TSC can maintain a list of strategic projects, or make an effort to include their participants and maintainers in relevant TSC discussions.
+
+The CHIPS Alliance TSC is grateful to the broader open source ecosystem, and is looking forward to healthy collaboration within and external to the Alliance.
+
 ## Policies and procedures
 
 The CHIPS Alliance TSC is governed by the [Technical Charter](CHARTER.md). The Charter provides a foundational structure for the TSC on topics such as its scope, how to make decisions, and how to make changes to itself. At the same time, it grants the TSC a high degree of freedom when determining how to implement the policies of CHIPS Alliance.


### PR DESCRIPTION
Per discussions via email, adding a section on the strategic importance of non-CHIPS Alliance projects, and possible ways in which the TSC may engage their expertise.

Signed-off-by: Brian Warner <brian@bdwarner.com>