### PR TITLE
Fix description of archived project

### DIFF
--- a/projects/README.md
+++ b/projects/README.md
@@ -8,7 +8,7 @@ There are three project categories:
 
 * [Sandbox](#sandbox): Optional pre-membership stage to help a project prepare for the TSC's consideration.
 * [Graduated](#graduated): A project which has met the graduation requirements and demonstrated sustainable momentum.
-* [Archived](#archived): When an Archival proposal is accepted, the PR may be landed and closed.): A former Graduated project which has been archived for strategic or practical reasons.
+* [Archived](#archived): A former Graduated project which has been archived for strategic or practical reasons.
 
 
 ## Sandbox


### PR DESCRIPTION
https://github.com/chipsalliance/tsc/blob/main/projects/README.md#introduction

The description features a dandling bracket which seems like a copy paste error - the sentence before it seems out of place. I assume it's a simple mistake, but not sure if the sentence should not be moved somewhere? Can't spot anything missing but I don't have access to where this is copied from. See below:

Archived: ~When an Archival proposal is accepted, the PR may be landed and closed.):~ A former Graduated project which has been archived for strategic or practical reasons.