### PR TITLE
Fix #183 Add Github Repo Policy

### DIFF
--- a/GITHUB_POLICY.md
+++ b/GITHUB_POLICY.md
@@ -1,0 +1,78 @@
+# CHIPS Alliance Github Organization Policy For Existing Projects
+
+## Introduction
+
+This document outlines the policies and guidelines for creating **new** repositories within the CHIPS Alliance GitHub organization. These policies are intended for projects that are already part of CHIPS Alliance and are working in the CHIPS Alliance Github Organization. 
+
+## Repository Creation and Management
+
+### Private Repositories
+
+- Creation Permission: Projects are permitted to create private repositories as needed without prior approval.
+- Usage: Private repositories should be used for internal development, sensitive information, or any content not yet ready for public disclosure.
+
+### Public Repositories
+
+#### Approval Process
+
+- Submission Requirement: To create a new public repository or convert an existing private repository to public, 
+  the project must submit an issue to [this Github Repository](https://github.com/chipsalliance/tac/issues/new/choose).
+- Review Body: The Technical Advisory Committee (TAC) will review all submissions.
+- Decision Criteria: The TAC will assess compliance with the policies outlined in this document.
+
+#### Requirements for Public Repositories
+
+1.	Contributor License Agreement (CLA) Enforcement
+    - Mandatory CLA: All public repositories must have CLA enforcement enabled.
+    - Assistance: CHIPS Alliance will provide support to set up CLA enforcement mechanisms.
+2.	Licensing
+    - LICENSE.md File: A valid LICENSE.md file must be included in the repository.
+    - Compliance: The license must adhere to the [CHIPS Alliance IP Guidelines](https://participation-agreement.chipsalliance.org/), Apache 2.0 unless special exception is granted.
+3.	Project Affiliation
+    - Direct Operation: The repository must be directly operated by a CHIPS Alliance project.
+    - Clear Identification: The project affiliation should be evident in the repository’s description and documentation.
+
+#### Repository Naming Conventions
+
+To maintain a clear and organized repository structure, all repositories should follow a consistent and descriptive naming
+convention. This practice helps in grouping related repositories together when sorted alphabetically.
+
+#####  Naming Guidelines
+
+- Format: Use the following format for repository names:
+
+```
+[project-name]
+[project-name]-[descriptor]
+```
+
+- Project Name: Use a concise and consistent identifier for your project.
+- Descriptor: Use a descriptive term to indicate the repository’s purpose (e.g., website, admin, ci, mentorship).
+- Separator: Use a hyphen (-) to separate the project name and descriptor.
+
+##### Examples
+
+* project1
+* project1-website
+* project1-admin
+* project2
+* project2-ci
+* project2-mentorship
+* project2-website
+
+ #### Additional Recommendations
+
+- Consistency: Ensure consistent use of project names and descriptors across all repositories.
+- Clarity: Choose descriptors that clearly reflect the content or purpose of the repository.
+- Avoid Abbreviations: Unless commonly understood, avoid using abbreviations that might confuse contributors or users.
+
+#### Compliance and Enforcement
+
+- Periodic Reviews: The TAC may conduct periodic reviews of repositories to ensure ongoing compliance with these policies.
+- Non-Compliance Resolution: Repositories found in violation may be subject to removal or reversion to private status until compliance is achieved.
+- Feedback Mechanism: Projects will be notified of any issues and provided with guidance on how to comply.
+
+#### Support and Resources
+
+- Assistance with CLA: For help setting up CLA enforcement, contact [operations@chipsalliance.org](mailto:operations@chipsalliance.org).
+- Questions and Clarifications: For any questions regarding these policies, reach out to the TAC or [operations@chipsalliance.org](mailto:operations@chipsalliance.org).

--- a/GITHUB_POLICY.md
+++ b/GITHUB_POLICY.md
@@ -32,14 +32,14 @@ This document outlines the policies and guidelines for creating **new** reposito
     - Direct Operation: The repository must be directly operated by a CHIPS Alliance project.
     - Clear Identification: The project affiliation should be evident in the repository’s description and documentation.
 
-#### Repository Naming Conventions
+#### Recommended Repository Naming Conventions
 
-To maintain a clear and organized repository structure, all repositories should follow a consistent and descriptive naming
+To maintain a clear and organized repository structure, we recommend repositories follow a consistent and descriptive naming
 convention. This practice helps in grouping related repositories together when sorted alphabetically.
 
 #####  Naming Guidelines
 
-- Format: Use the following format for repository names:
+- Format: We recommend but do not enforece the following format for repository names:
 
 ```
 [project-name]
@@ -65,6 +65,7 @@ convention. This practice helps in grouping related repositories together when s
 - Consistency: Ensure consistent use of project names and descriptors across all repositories.
 - Clarity: Choose descriptors that clearly reflect the content or purpose of the repository.
 - Avoid Abbreviations: Unless commonly understood, avoid using abbreviations that might confuse contributors or users.
+- Ensure that your [project's .yaml file](https://github.com/chipsalliance/tac/tree/main/projects/project-data-files) is kept up to date and lists all the public repositories associated with your project. 
 
 #### Compliance and Enforcement
 


### PR DESCRIPTION
Once the policy is approved there are a few things we will need to do to actually enforce:

1. Let projects know about the change and policy
2. Adjust the org permissions so that members can not create public repos https://github.com/enterprises/chips-alliance/settings/member_privileges
3. Create a role that has the permissions to create public repos and assign this role to the tac (I will need help on sorting this out)
4. Note some folks have admin perms on the org due to github actions permissions, we will need to address this. 