### PR TITLE
Update omnixtend.yml - set stats of project to Archived

### DIFF
--- a/projects/project-data-files/omnixtend.yml
+++ b/projects/project-data-files/omnixtend.yml
@@ -1,6 +1,6 @@
 name: OmniXtend
 # Project status - sandbox, graduated or archived
-status: graduated
+status: archived
 # Links to project repos - may be one or list of several in YAML list format
 repositories:
   - https://github.com/chipsalliance/omnixtend


### PR DESCRIPTION
This PR will update the status of OmnixExtend to archived and follows the process outlined [here](https://github.com/chipsalliance/tac/tree/main/projects#archived).

The rational for archiving the project is based on the [repository](https://github.com/chipsalliance/omnixtend) being set to read only in 2023.  There were some initial discussions about the project coming back but we have not heard anything since June.

This topic should be discussed in the next TAC meeting @cetola 